### PR TITLE
LayerListControls item not found fix

### DIFF
--- a/packages/vue-components/lib/components/LayerListControls/LayerListControls.vue
+++ b/packages/vue-components/lib/components/LayerListControls/LayerListControls.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script>
-import { watch, ref, toRefs, computed } from '@vue/composition-api'
+import { watch, ref, toRefs, computed, onMounted } from '@vue/composition-api'
 import addIndex from './add-index'
 import findInTree from './find-in-tree'
 import addParentIdToLayers from './add-parent-id-to-layers'
@@ -57,6 +57,10 @@ export default {
     const { setSelectedIds, selectedIds } = useSelected()
     const { activeLegend, setActiveLegend } = useLegend(selectedIds)
     const { onSortingChange } = useSortable(layers, root, openItems)
+
+    onMounted(() => {
+      setSelectedIds([])
+    })
 
     const sortedSelectedLayers = computed(() => {
       const withIndex = addIndex(layers.value)


### PR DESCRIPTION
When I use the component in an application where it's used in multiple pages, i get this error:

![image](https://user-images.githubusercontent.com/11621275/102061295-9325b000-3df3-11eb-8185-a8a2ba112d0d.png)

It's kind of critical because the component does not function as expected after that.

This happens even if I force rerender the component. It seems like the `selectedIds` is not cleared when a new instance of the component is rerenderd.

My solution is to clear it manually on every mount.